### PR TITLE
feat: improve wrkt switch - to toggle between directories

### DIFF
--- a/cmd/shell_init.go
+++ b/cmd/shell_init.go
@@ -29,7 +29,9 @@ function wrkt() {
         if [ "$2" = "-" ]; then
           # Handle switch to previous worktree
           if [ -n "$WRKT_OLDPWD" ]; then
+            local current_pwd="$PWD"
             cd "$WRKT_OLDPWD"
+            export WRKT_OLDPWD="$current_pwd"
           else
             echo "wrkt: no previous worktree" >&2
             return 1

--- a/test/switch-previous.sh
+++ b/test/switch-previous.sh
@@ -117,6 +117,29 @@ else
     fail_test "Implementation doesn't properly check WRKT_OLDPWD"
 fi
 
+# Test 8: Consecutive wrkt switch - behavior (A → B → A)
+echo
+echo "Test 8: Consecutive switch - behavior"
+current_dir=$(pwd)
+info "Testing consecutive wrkt switch - commands"
+
+# Test A → B → A pattern
+result=$(zsh -c "
+export PATH='$current_dir:\$PATH'
+eval \"\$(wrkt shell-init)\" 2>/dev/null
+cd /tmp
+export WRKT_OLDPWD='/var'
+wrkt switch - >/dev/null 2>&1
+wrkt switch - >/dev/null 2>&1
+echo \"\$(pwd)\"
+")
+
+if [[ "$result" == "/tmp" ]]; then
+    pass_test "Consecutive switch - correctly toggles between locations"
+else
+    fail_test "Consecutive switch - failed to toggle (result: $result, expected: /tmp)"
+fi
+
 # Final results
 echo
 echo "======================================"


### PR DESCRIPTION
## Summary
- Enhance `wrkt switch -` to support consecutive toggling between directories (A→B→A pattern)
- Update shell integration to save current directory when switching to previous location
- Add comprehensive test coverage for consecutive switch behavior

## Test plan
- [x] Add test case for consecutive `wrkt switch -` commands
- [x] Verify A→B→A toggle behavior works correctly
- [x] Ensure all existing tests continue to pass
- [x] Run full test suite with zsh integration

🤖 Generated with [Claude Code](https://claude.ai/code)